### PR TITLE
Fix header component name

### DIFF
--- a/src/components/header/Header.jsx
+++ b/src/components/header/Header.jsx
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 import styles from './Header.module.css';
 import { ColorContext } from '../../shared/Color.context';
 
-const CounterUnit = ({ children }) => {
+const Header = ({ children }) => {
   const { color } = useContext(ColorContext);
   return (
     <div className={styles.header} style={{ color }}>
@@ -11,4 +11,4 @@ const CounterUnit = ({ children }) => {
   );
 };
 
-export default CounterUnit;
+export default Header;


### PR DESCRIPTION
## Summary
- rename Header component variable to match filename

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68516d35e2b88324b0540f261a1008ec