### PR TITLE
Rename hexcolor param to hexColor

### DIFF
--- a/src/shared/Color.service.js
+++ b/src/shared/Color.service.js
@@ -1,7 +1,7 @@
-export function getContrast(hexcolor) {
-  const r = parseInt(hexcolor.substr(1, 2), 16);
-  const g = parseInt(hexcolor.substr(3, 2), 16);
-  const b = parseInt(hexcolor.substr(5, 2), 16);
+export function getContrast(hexColor) {
+  const r = parseInt(hexColor.substr(1, 2), 16);
+  const g = parseInt(hexColor.substr(3, 2), 16);
+  const b = parseInt(hexColor.substr(5, 2), 16);
   const yiq = (r * 299 + g * 587 + b * 114) / 1000;
   return yiq >= 128 ? 'black' : 'white';
 }


### PR DESCRIPTION
## Summary
- rename `hexcolor` parameter to `hexColor` in `Color.service`

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851748c44388324afa67899e61663a6